### PR TITLE
feat: rotating top icon and wrapper.sh small changes

### DIFF
--- a/config/template/gitlab-config.template
+++ b/config/template/gitlab-config.template
@@ -8,6 +8,8 @@ check_membership = True
 only_projects_with_pipelines = True
 # 'name' or 'activity'
 sort_on = activity
+sort_reverse = False
+alternate_header = False
 # limit to projects with activity in the last x weeks
 only_projects_last_weeks = 2
 # Names must match the sections below exactly

--- a/src/python/gitlab/__main__.py
+++ b/src/python/gitlab/__main__.py
@@ -60,9 +60,17 @@ for instance in GitlabConfig.GITLAB_HOSTS:
         continue
 
 # Now construct the bitbar menu
+if GitlabConfig.ALTERNATE_HEADER:
+    for k,v in statuses.items():
+        print(str(v) + "|image=" + GitlabIcons.STATUS[k].base64_image)
+else:
+    failures = statuses.get(PipelineStatus.FAILURE,0)
+    if failures > 0:
+        print(str(failures) + "|image=" + \
+                GitlabIcons.STATUS[PipelineStatus.FAILURE].base64_image)
+    else:
+        print("|image=" + GitlabIcons.STATUS[PipelineStatus.SUCCESS].base64_image)
 
-for k,v in statuses.items():
-    print(str(v) + "|image=" + GitlabIcons.STATUS[k].base64_image)
 
 for instance in bitbar_gitlab_projects:
     # Start menu items

--- a/src/python/gitlab/__main__.py
+++ b/src/python/gitlab/__main__.py
@@ -85,6 +85,19 @@ if overall_status == PipelineStatus.FAILURE:
 else:
     print("|image=" + GitlabIcons.STATUS[overall_status].base64_image)
 
+if status_failure_building > 0 :
+    print(str(status_failure_building) + "|image=" +
+            GitlabIcons.STATUS[PipelineStatus.FAILURE_BUILDING].base64_image)
+if status_success_building > 0 :
+    print(str(status_success_building) + "|image=" +
+            GitlabIcons.STATUS[PipelineStatus.SUCCESS_BUILDING].base64_image)
+if status_failure > 0 :
+    print(str(status_failure) + "|image=" +
+            GitlabIcons.STATUS[PipelineStatus.FAILURE].base64_image)
+if status_success > 0 :
+    print(str(status_success) + "|image=" +
+            GitlabIcons.STATUS[PipelineStatus.SUCCESS].base64_image)
+
 for instance in bitbar_gitlab_projects:
     # Start menu items
     gitlab_name = instance['gitlab_name']

--- a/src/python/gitlab/__main__.py
+++ b/src/python/gitlab/__main__.py
@@ -1,5 +1,6 @@
 import dateutil.parser
 from requests import Timeout
+from collections import defaultdict
 
 from . import GitlabConfig, PipelineStatus, get_projects, get_most_recent_project_pipeline_status, GitlabIcons
 from ..common.util import time_ago
@@ -8,10 +9,7 @@ overall_status = PipelineStatus.INACTIVE
 bitbar_gitlab_projects = []
 
 # Overall status counters
-status_failure_building = 0
-status_success_building = 0
-status_failure = 0
-status_success = 0
+statuses = defaultdict(int)
 
 for instance in GitlabConfig.GITLAB_HOSTS:
     host = instance['host']
@@ -35,15 +33,7 @@ for instance in GitlabConfig.GITLAB_HOSTS:
 
             if GitlabConfig.ONLY_PROJECTS_WITH_PIPELINES and pipeline_status == PipelineStatus.INACTIVE:
                 continue
-
-            if pipeline_status == PipelineStatus.FAILURE_BUILDING:
-                status_failure_building += 1
-            elif pipeline_status == PipelineStatus.SUCCESS_BUILDING:
-                status_success_building += 1
-            elif pipeline_status == PipelineStatus.FAILURE:
-                status_failure += 1
-            elif pipeline_status == PipelineStatus.SUCCESS:
-                status_success += 1
+            statuses[pipeline_status] += 1
 
             gitlab_instance_projects.append(dict(
                 id=project_id,
@@ -70,33 +60,9 @@ for instance in GitlabConfig.GITLAB_HOSTS:
         continue
 
 # Now construct the bitbar menu
-if status_failure_building > 0:
-    overall_status = PipelineStatus.FAILURE_BUILDING
-elif status_success_building > 0:
-    overall_status = PipelineStatus.SUCCESS_BUILDING
-elif status_failure > 0:
-    overall_status = PipelineStatus.FAILURE
-elif status_success > 0:
-    overall_status = PipelineStatus.SUCCESS
 
-# Set menubar icon
-if overall_status == PipelineStatus.FAILURE:
-    print(str(status_failure) + "|image=" + GitlabIcons.STATUS[overall_status].base64_image)
-else:
-    print("|image=" + GitlabIcons.STATUS[overall_status].base64_image)
-
-if status_failure_building > 0 :
-    print(str(status_failure_building) + "|image=" +
-            GitlabIcons.STATUS[PipelineStatus.FAILURE_BUILDING].base64_image)
-if status_success_building > 0 :
-    print(str(status_success_building) + "|image=" +
-            GitlabIcons.STATUS[PipelineStatus.SUCCESS_BUILDING].base64_image)
-if status_failure > 0 :
-    print(str(status_failure) + "|image=" +
-            GitlabIcons.STATUS[PipelineStatus.FAILURE].base64_image)
-if status_success > 0 :
-    print(str(status_success) + "|image=" +
-            GitlabIcons.STATUS[PipelineStatus.SUCCESS].base64_image)
+for k,v in statuses.items():
+    print(str(v) + "|image=" + GitlabIcons.STATUS[k].base64_image)
 
 for instance in bitbar_gitlab_projects:
     # Start menu items

--- a/src/python/gitlab/__main__.py
+++ b/src/python/gitlab/__main__.py
@@ -75,10 +75,8 @@ for instance in bitbar_gitlab_projects:
     else:
         print(f"{gitlab_name} |templateImage={GitlabIcons.GITLAB_LOGO.base64_image}")
 
-        sorted_projects = sorted(instance['projects'], key=lambda p: p['activity'],
-                                 reverse=True) if GitlabConfig.SORT_ON == 'activity' else sorted(
-            instance['projects'],
-            key=lambda p: p['name'])
+        sorted_projects = sorted(instance['projects'], key=lambda p:
+                str(p[GitlabConfig.SORT_ON]), reverse=GitlabConfig.SORT_REVERSE)
 
         for project in sorted_projects:
             print(f"{project['name']}  -  {project['time_ago']} |href={project['href']} image={project['image'].base64_image}")

--- a/src/python/gitlab/config.py
+++ b/src/python/gitlab/config.py
@@ -17,6 +17,7 @@ class GitlabConfig(object):
     ONLY_PROJECTS_LAST_WEEKS = _config['preferences'].get('only_projects_last_weeks', None)
 
     SORT_ON = _config['preferences'].get('sort_on', 'activity')
+    SORT_REVERSE = strtobool(_config['preferences'].get('sort_reverse', "False"))
 
     API_PROJECTS = '/api/v4/projects'
     API_PIPELINES = '/pipelines'

--- a/src/python/gitlab/config.py
+++ b/src/python/gitlab/config.py
@@ -18,6 +18,7 @@ class GitlabConfig(object):
 
     SORT_ON = _config['preferences'].get('sort_on', 'activity')
     SORT_REVERSE = strtobool(_config['preferences'].get('sort_reverse', "False"))
+    ALTERNATE_HEADER = strtobool(_config['preferences'].get('alternate_header', "False"))
 
     API_PROJECTS = '/api/v4/projects'
     API_PIPELINES = '/pipelines'

--- a/src/wrapper.sh
+++ b/src/wrapper.sh
@@ -1,17 +1,19 @@
 #!/usr/bin/env bash
+
 DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd $DIR
 
 MODULE_NAME="$1"
 CONFIG_MODULE_NAME="$2"
-PATH_TO_CONFIG_FILE=
 
 if [ -z "$CONFIG_MODULE_NAME" ]; then
-  PATH_TO_CONFIG_FILE="$DIR/../config/$MODULE_NAME-config.ini"
+  PATH_TO_CONFIG_FILE="../config/$MODULE_NAME-config.ini"
 else
-  PATH_TO_CONFIG_FILE="$DIR/../config/$CONFIG_MODULE_NAME-config.ini"
+  PATH_TO_CONFIG_FILE="../config/$CONFIG_MODULE_NAME-config.ini"
 fi
 
 # Get path to Python as defined in the config file of this module
 PYTHON_BIN="$(awk -F '=' '{if (! ($0 ~ /^;/) && $0 ~ /python_binary/) print $2}' "$PATH_TO_CONFIG_FILE" | xargs)"
+PYTHON_BIN=${PYTHON_BIN:-python3}
 
 "$PYTHON_BIN" -m "python.$MODULE_NAME"


### PR DESCRIPTION
The first few lines before the `---` can rotate icons, and this way we also see the other statuses.

I've also patched `wrapper.sh` so that it can be run from anywhere (with a full path), and that it uses a default Python binary if you don't set it in the ini file.